### PR TITLE
Fix passing NoneType as artist_text to add_text_to_image() in Prompts…

### DIFF
--- a/src/piblo/pycasso.py
+++ b/src/piblo/pycasso.py
@@ -367,6 +367,7 @@ class Pycasso:
             prompt_gen = self.prep_normal_prompt(self.config.prompts_file, self.config.prompt_preamble,
                                                  self.config.prompt_postscript, self.config.parse_brackets)
             prompt, title_text = prompt_gen
+            artist_text = ""
         else:
             warnings.warn("Invalid prompt mode chosen. Using default prompt mode.")
             # Build prompt from prompt file


### PR DESCRIPTION
Image generation would fail for me when in "Prompt" mode (i.e., using prompts.txt with mode=2 in .config), with message:

> Traceback (most recent call last):
>   File "/home/pi/pycasso/scripts/run.py", line 26, in <module>
>     instance.run()
>   File "/home/pi/pycasso/src/piblo/pycasso.py", line 551, in run
>     prompt, metadata, artist_text, title_text = self.prep_prompt_text(self.config.prompt_mode)
>   File "/home/pi/pycasso/src/piblo/pycasso.py", line 358, in prep_prompt_text
>     prompt_gen = self.prep_subject_artist_prompt(self.config.artists_file, self.config.subjects_file,
>   File "/home/pi/pycasso/src/piblo/pycasso.py", line 393, in prep_subject_artist_prompt
>     artist_text = FileOperations.get_random_line(artists_file)
>   File "/home/pi/pycasso/src/piblo/file_operations.py", line 143, in get_random_line
>     lines = FileOperations.get_lines(path)
>   File "/home/pi/pycasso/src/piblo/file_operations.py", line 136, in get_lines
>     with open(path, encoding=encoding) as file:
> TypeError: expected str, bytes or os.PathLike object, not NoneType


I think the reason is that artist_text remained a NoneType when in "Prompt" mode.