### PR TITLE
Automatic1111 Support

### DIFF
--- a/examples/.config-example
+++ b/examples/.config-example
@@ -182,6 +182,7 @@ external_amount = 0
 historic_amount = 0
 stability_amount = 0
 dalle_amount = 0
+automatic_amount = 0
 
 # Whether to use keychain to manage keys. When set to false will just look for .creds file with credentials in it.
 # [boolean]

--- a/src/piblo/config_wrapper.py
+++ b/src/piblo/config_wrapper.py
@@ -91,6 +91,7 @@ class Configs:
         self.historic_amount = ProvidersConst.HISTORIC_AMOUNT.value
         self.stability_amount = ProvidersConst.STABLE_AMOUNT.value
         self.dalle_amount = ProvidersConst.DALLE_AMOUNT.value
+        self.automatic_amount = ProvidersConst.AUTOMATIC_AMOUNT.value
         self.use_keychain = ProvidersConst.USE_KEYCHAIN.value
         self.credential_path = self.file.get_full_path(ProvidersConst.CREDENTIAL_PATH.value)
         self.test_enabled = ProvidersConst.TEST_ENABLED.value
@@ -193,6 +194,8 @@ class Configs:
                                                   fallback=ProvidersConst.STABLE_AMOUNT.value)
             self.dalle_amount = config.getint("Providers", "dalle_amount",
                                               fallback=ProvidersConst.DALLE_AMOUNT.value)
+            self.automatic_amount = config.getint("Providers", "automatic_amount",
+                                                  fallback=ProvidersConst.AUTOMATIC_AMOUNT.value)
             self.use_keychain = config.getboolean("Providers", "use_keychain",
                                                   fallback=ProvidersConst.USE_KEYCHAIN.value)
             self.credential_path = config.get("Providers", "credential_path",

--- a/src/piblo/constants.py
+++ b/src/piblo/constants.py
@@ -90,11 +90,13 @@ class ProvidersConst(Enum):
     STABLE = 2
     DALLE = 3
     MIDJOURNEY = 4
+    AUTOMATIC = 5
 
     EXTERNAL_AMOUNT = 0
     HISTORIC_AMOUNT = 0
     STABLE_AMOUNT = 0
     DALLE_AMOUNT = 0
+    AUTOMATIC_AMOUNT = 0
 
     USE_KEYCHAIN = False
     CREDENTIAL_PATH = ".creds"
@@ -115,7 +117,11 @@ class StabilityConst(Enum):
     HOST = "STABILITY_HOST"
     DEFAULT_HOST = "grpc.stability.ai:443"
     MULTIPLE = 64
-
+    
+class AutomaticConst(Enum):
+    HOST = "AUTOMATIC_HOST"
+    DEFAULT_HOST = "http://127.0.0.1:7860"
+    MULTIPLE = 64
 
 class DalleConst(Enum):
     SIZES = {


### PR DESCRIPTION
This adds support for local installations of the Automatic1111 Stable Diffusion webui.

Needs to ensure the webui is launched with the `--api` argument, else this won't work.

Hopefully this works, I kinda hacked it together without really logging what I was doing, then had to go back and discover all my changes :P